### PR TITLE
Platform Support Error and Big Endianness

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -4,6 +4,8 @@ use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum EmulatorError {
-    #[error("IO-Error: {0}")]
+    #[error("IOError: {0}")]
     IoError(#[from] io::Error),
+    #[error("PlatformError: {0}")]
+    PlatformError(String),
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,12 @@ struct Cli {
 }
 
 fn main() -> Result<(), EmulatorError> {
+    if cfg!(target_endian = "big") {
+        return Err(EmulatorError::PlatformError(
+            "This emulator only supports little endianness.".to_string(),
+        ));
+    }
+
     println!("Hello, gameboys!");
 
     let cli = Cli::parse();

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,14 @@ struct Cli {
     debug: bool,
 }
 
-fn main() -> Result<(), EmulatorError> {
+fn main() {
+    let result = run();
+    if let Err(error) = result {
+        println!("{}", error);
+    }
+}
+
+fn run() -> Result<(), EmulatorError> {
     if cfg!(target_endian = "big") {
         return Err(EmulatorError::PlatformError(
             "This emulator only supports little endianness.".to_string(),
@@ -33,7 +40,7 @@ fn main() -> Result<(), EmulatorError> {
             .to_str()
             .expect("Game file path should be valid string")
     );
-    println!("Debug mode: {:?}", cli.debug);
+    println!("Debug mode: {}", cli.debug);
 
     if !cli.game_file.is_file() {
         println!("Provided path is not a file");

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use std::{fs::File, io::Read, path::PathBuf, time::Instant};
+use std::{fs::File, io::Read, path::PathBuf, process::ExitCode, time::Instant};
 
 use clap::Parser;
 
@@ -17,11 +17,13 @@ struct Cli {
     debug: bool,
 }
 
-fn main() {
+fn main() -> ExitCode {
     let result = run();
     if let Err(error) = result {
         println!("{}", error);
+        return ExitCode::FAILURE;
     }
+    ExitCode::SUCCESS
 }
 
 fn run() -> Result<(), EmulatorError> {


### PR DESCRIPTION
Because I do not intend to maintain support for more than the most common platforms, this PR introduces an error type for letting the user know that their platform is not supported.
And I already added such a check, prohibiting big endianness, because most computer systems today use little endianness and the Gameboy used little endianness as well.
Little endianness is thus easy to implement and maintain, while big endianness would be more difficult to implement, test, and maintain.