### PR TITLE
Macro for pattern matching on bytes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,10 +98,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
 
 [[package]]
+name = "either"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+
+[[package]]
 name = "gameboy-emulator"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "itertools",
+ "quote",
  "thiserror",
 ]
 
@@ -116,6 +124,15 @@ name = "is_terminal_polyfill"
 version = "1.70.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8478577c03552c21db0e2724ffb8986a5ce7af88107e6be5d2ee6e158c12800"
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "proc-macro2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,4 +5,9 @@ edition = "2021"
 
 [dependencies]
 clap = { version = "4.5.4", features = ["derive"] }
+itertools = "0.13.0"
+quote = "1.0.36"
 thiserror = "1.0.61"
+
+[lib]
+proc-macro = true

--- a/src/bitstring_matching.rs
+++ b/src/bitstring_matching.rs
@@ -1,0 +1,87 @@
+extern crate proc_macro;
+use std::iter::once;
+
+use itertools::{repeat_n, Itertools};
+use proc_macro::{Literal, Punct, Spacing, TokenStream, TokenTree};
+use quote::quote;
+
+enum Bit {
+    One,
+    Zero,
+    Free,
+}
+
+pub fn generate_all_bitstrings(token_stream: TokenStream) -> TokenStream {
+    if token_stream.is_empty() {
+        return quote! {
+            compile_error!("Expected exactly one literal indicating a bitstring pattern.");
+        }
+        .into();
+    }
+
+    let mut iter = token_stream.into_iter();
+    let token = iter.next().unwrap();
+
+    if iter.next().is_some() {
+        return quote! {
+            compile_error!("Expected exactly one literal indicating a bitstring pattern.");
+        }
+        .into();
+    }
+
+    let bitstring = token.to_string();
+
+    if bitstring.len() != 8 {
+        return quote! {
+            compile_error!("Expected a bitstring pattern of length 8.");
+        }
+        .into();
+    }
+
+    let positions: Vec<Bit> = bitstring
+        .chars()
+        .filter_map(|c| {
+            if c == '_' {
+                Some(Bit::Free)
+            } else if c == '0' {
+                Some(Bit::Zero)
+            } else if c == '1' {
+                Some(Bit::One)
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    if positions.len() != 8 {
+        return quote! {
+            compile_error!("The bitstring pattern may only contain '0', '1', and '_'.");
+        }
+        .into();
+    }
+
+    let mut vals: Vec<u8> = vec![0];
+    for (i, position) in positions.into_iter().rev().enumerate() {
+        match position {
+            Bit::One => vals = vals.into_iter().map(|val| val + (1 << i)).collect(),
+            Bit::Zero => {}
+            Bit::Free => {
+                vals = vals
+                    .into_iter()
+                    .flat_map(|val| once(val).chain(once(val + (1 << i))))
+                    .collect()
+            }
+        };
+    }
+    assert!(!vals.is_empty());
+
+    let separators = repeat_n(
+        TokenTree::Punct(Punct::new('|', Spacing::Alone)),
+        vals.len() - 1,
+    );
+    let literals = vals
+        .into_iter()
+        .map(|val| TokenTree::Literal(Literal::u8_suffixed(val)));
+
+    TokenStream::from_iter(literals.interleave(separators))
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,22 @@
+extern crate proc_macro;
+use proc_macro::TokenStream;
+
+mod bitstring_matching;
+
+/// This macros expands 8-bit patterns to all the possible u8 values that should be matched.
+/// Example:
+/// ```
+/// # #[macro_use] extern crate gameboy_emulator;
+/// # for byte in 0..=u8::MAX {
+/// match byte /* u8 */ {
+///     bits!(00001111) => assert_eq!(byte, 15),
+///     bits!(_____101) => assert_eq!(byte % 8, 5),
+///     bits!(00__1011) => assert_eq!(byte & 0b11001111, 0b00001011),
+///     _ => {},
+/// }
+/// # }
+///
+#[proc_macro]
+pub fn bits(token_stream: TokenStream) -> TokenStream {
+    bitstring_matching::generate_all_bitstrings(token_stream)
+}

--- a/tests/bitstring_matching.rs
+++ b/tests/bitstring_matching.rs
@@ -1,0 +1,27 @@
+use gameboy_emulator::bits;
+
+#[test]
+fn simple_bitstring_matching() {
+    for i in 0..=u8::MAX {
+        match i {
+            bits!(00000101) => assert_eq!(i, 5),
+            bits!(__100010) => assert_eq!(i & 0b00111111, 0b00100010),
+            _ => {}
+        }
+    }
+}
+
+#[test]
+fn mixed_bitstring_matching() {
+    for i in 0..=u8::MAX {
+        match i {
+            bits!(0000010_) | bits!(_0000_01) => {
+                assert!([0b00000001, 0b00000100, 0b00000101, 0b10000001, 0b10000101].contains(&i))
+            }
+            bits!(__11____) => {
+                assert_eq!(i & 0b00110000, 0b00110000)
+            }
+            _ => {}
+        }
+    }
+}


### PR DESCRIPTION
This PR implements the `bits!` macro to simplify pattern matching on bytes.
Now we can parse instructions in the following way:
```rust
match byte {
    bits!(00__0001) => { // instruction: ld dest, immediate
        let dest = (byte >> 4) & 0b11;
        ...
    },
    ...
}
```
Notice, that the macro only matches and does not extract the matched bits.